### PR TITLE
add .travis.yml (resolves issue #26)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+cache:
+	directories:
+		- node_modules
+node_js:
+	- node


### PR DESCRIPTION
your problem was due to a missing `.travis.yml` config. without that travis used its default config, which instructs it to run ruby.
