### PR TITLE
Fix syntax in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
+--- 
+before_script: 
+  - "npm install -g gulp"
 language: node_js
-cache:
-	directories:
-		- node_modules
-node_js:
-	- node
+node_js: 
+  - node
+script: gulp


### PR DESCRIPTION
 `travis.yml` currently contains incorrect YAML syntax, which is causing the build errors (issue #26). I've reformatted and restructured it to use the latest stable Node build, then run your Gulpfile.
